### PR TITLE
fix: use raw.githubusercontent.com for logo image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!-- PROJECT LOGO -->
 <br />
 <p align="center">
-  <img alt="delineate.io" src="https://github.com/delineateio/.github/blob/master/assets/logo.png?raw=true" height="75" />
+  <img alt="delineate.io" src="https://raw.githubusercontent.com/delineateio/.github/main/assets/logo.png" height="75" />
   <h2 align="center">delineate.io</h2>
   <p align="center">portray or describe (something) precisely.</p>
 


### PR DESCRIPTION
## Summary
- Replace the GitHub blob URL (`github.com/.../blob/...?raw=true`) with the direct raw content URL (`raw.githubusercontent.com`) so the logo renders correctly in HTML `<img>` tags.

## Test plan
- [ ] Verify the logo image renders in the README preview on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)